### PR TITLE
Add "parcel" to tracking filter's subject keywords

### DIFF
--- a/filters/05 - paper trail.sieve
+++ b/filters/05 - paper trail.sieve
@@ -128,6 +128,7 @@ if not anyof(
         ".*(^|[^a-zA-Z0-9])label([^a-zA-Z0-9]|$).*",
         ".*(^|[^a-zA-Z0-9])order([^a-zA-Z0-9]|$).*",
         ".*(^|[^a-zA-Z0-9])package([^a-zA-Z0-9]|$).*",
+        ".*(^|[^a-zA-Z0-9])parcel([^a-zA-Z0-9]|$).*",
         ".*(^|[^a-zA-Z0-9])payment([^a-zA-Z0-9]|$).*",
         ".*(^|[^a-zA-Z0-9])forwarding([^a-zA-Z0-9]|$).*",
         ".*(^|[^a-zA-Z0-9])shipment([^a-zA-Z0-9]|$).*"


### PR DESCRIPTION
## Summary
- CouriersPlease emails ("We have delivered your parcel", "Your parcel is on its way") were going to Trash instead of tracking/Paper Trail
- Root cause: "parcel" was missing from the tracking rule's first `allof` subject list (the thing-being-tracked list), so the `allof` never matched despite status words like "delivered" and "on its way" being present in the second list
- Added "parcel" alongside existing entries like "package", "order", "shipment"

## Test plan
- [x] `bash tests/generate_test.sh` — all 29 tests pass
- [ ] Verify CouriersPlease "We have delivered your parcel" goes to tracking + Paper Trail
- [ ] Verify CouriersPlease "Your parcel is on its way" goes to tracking + Paper Trail

https://claude.ai/code/session_01TH83QZwrkfoVFQtjaacFLk