### PR TITLE
Fix returns not captured when the returns word is only in the sender

### DIFF
--- a/filters/04 - alerts.sieve
+++ b/filters/04 - alerts.sieve
@@ -65,7 +65,7 @@ if allof(
 
 if allof(
   header :comparator "i;unicode-casemap" :regex "subject" [
-    ".*(^|[^a-zA-Z0-9])[0-9]{1,3}%([^a-zA-Z0-9]|$).*",
+    ".*(^|[^a-zA-Z0-9])[0-9]{1,3}% ?off([^a-zA-Z0-9]|$).*",
     ".*(^|[^a-zA-Z0-9])coupon([^a-zA-Z0-9]|$).*",
     ".*(^|[^a-zA-Z0-9])discount([^a-zA-Z0-9]|$).*",
     ".*(^|[^a-zA-Z0-9])sale([^a-zA-Z0-9]|$).*",

--- a/filters/05 - paper trail.sieve
+++ b/filters/05 - paper trail.sieve
@@ -81,11 +81,21 @@ if not anyof(
 
     # PAPER TRAIL - returns
 
-    header :comparator "i;unicode-casemap" :regex "subject" [
-      ".*(^|[^a-zA-Z0-9])return([^a-zA-Z0-9]|$).*",
-      ".*(^|[^a-zA-Z0-9])refund([^a-zA-Z0-9]|$).*",
-      ".*(^|[^a-zA-Z0-9])rma([^a-zA-Z0-9]|$).*"
-    ],
+    anyof(
+      header :comparator "i;unicode-casemap" :regex "subject" [
+        ".*(^|[^a-zA-Z0-9])return([^a-zA-Z0-9]|$).*",
+        ".*(^|[^a-zA-Z0-9])refund([^a-zA-Z0-9]|$).*",
+        ".*(^|[^a-zA-Z0-9])rma([^a-zA-Z0-9]|$).*"
+      ],
+      header :comparator "i;unicode-casemap" :regex [
+        "from",
+        "X-Simplelogin-Original-From"
+      ] [
+        ".*(^|[^a-zA-Z0-9])return([^a-zA-Z0-9]|$).*",
+        ".*(^|[^a-zA-Z0-9])refund([^a-zA-Z0-9]|$).*",
+        ".*(^|[^a-zA-Z0-9])rma([^a-zA-Z0-9]|$).*"
+      ]
+    ),
     header :comparator "i;unicode-casemap" :regex "subject" [
       ".*(^|[^a-zA-Z0-9])authoriz(e|ed|ing|ation)([^a-zA-Z0-9]|$).*",
       ".*(^|[^a-zA-Z0-9])by mail([^a-zA-Z0-9]|$).*",

--- a/filters/05 - paper trail.sieve
+++ b/filters/05 - paper trail.sieve
@@ -77,40 +77,39 @@ if not anyof(
     }
     fileinto "Paper Trail";
     stop;
-  } elsif allof (
+  } elsif anyof (
 
     # PAPER TRAIL - returns
 
-    anyof(
+    header :comparator "i;unicode-casemap" :regex [
+      "from",
+      "X-Simplelogin-Original-From"
+    ] [
+      ".*(^|[^a-zA-Z0-9])return([^a-zA-Z0-9]|$).*",
+      ".*(^|[^a-zA-Z0-9])refund([^a-zA-Z0-9]|$).*"
+    ],
+    allof(
       header :comparator "i;unicode-casemap" :regex "subject" [
         ".*(^|[^a-zA-Z0-9])return([^a-zA-Z0-9]|$).*",
         ".*(^|[^a-zA-Z0-9])refund([^a-zA-Z0-9]|$).*",
         ".*(^|[^a-zA-Z0-9])rma([^a-zA-Z0-9]|$).*"
       ],
-      header :comparator "i;unicode-casemap" :regex [
-        "from",
-        "X-Simplelogin-Original-From"
-      ] [
-        ".*(^|[^a-zA-Z0-9])return([^a-zA-Z0-9]|$).*",
-        ".*(^|[^a-zA-Z0-9])refund([^a-zA-Z0-9]|$).*",
-        ".*(^|[^a-zA-Z0-9])rma([^a-zA-Z0-9]|$).*"
+      header :comparator "i;unicode-casemap" :regex "subject" [
+        ".*(^|[^a-zA-Z0-9])authoriz(e|ed|ing|ation)([^a-zA-Z0-9]|$).*",
+        ".*(^|[^a-zA-Z0-9])by mail([^a-zA-Z0-9]|$).*",
+        ".*(^|[^a-zA-Z0-9])confirm(ed|ing|ation)([^a-zA-Z0-9]|$).*",
+        ".*(^|[^a-zA-Z0-9])complete(d|ing)?([^a-zA-Z0-9]|$).*",
+        ".*(^|[^a-zA-Z0-9])label([^a-zA-Z0-9]|$).*",
+        ".*(^|[^a-zA-Z0-9])notif(y|ied|ing|ication)([^a-zA-Z0-9]|$).*",
+        ".*(^|[^a-zA-Z0-9])parcel([^a-zA-Z0-9]|$).*",
+        ".*(^|[^a-zA-Z0-9])process(ed|ing)?([^a-zA-Z0-9]|$).*",
+        ".*(^|[^a-zA-Z0-9])order([^a-zA-Z0-9]|$).*",
+        ".*(^|[^a-zA-Z0-9])rma([^a-zA-Z0-9]|$).*",
+        ".*(^|[^a-zA-Z0-9])receive?(d|ing)?([^a-zA-Z0-9]|$).*",
+        ".*(^|[^a-zA-Z0-9])request([^a-zA-Z0-9]|$).*",
+        ".*(^|[^a-zA-Z0-9])your?([^a-zA-Z0-9]|$).*"
       ]
-    ),
-    header :comparator "i;unicode-casemap" :regex "subject" [
-      ".*(^|[^a-zA-Z0-9])authoriz(e|ed|ing|ation)([^a-zA-Z0-9]|$).*",
-      ".*(^|[^a-zA-Z0-9])by mail([^a-zA-Z0-9]|$).*",
-      ".*(^|[^a-zA-Z0-9])confirm(ed|ing|ation)([^a-zA-Z0-9]|$).*",
-      ".*(^|[^a-zA-Z0-9])complete(d|ing)?([^a-zA-Z0-9]|$).*",
-      ".*(^|[^a-zA-Z0-9])label([^a-zA-Z0-9]|$).*",
-      ".*(^|[^a-zA-Z0-9])notif(y|ied|ing|ication)([^a-zA-Z0-9]|$).*",
-      ".*(^|[^a-zA-Z0-9])parcel([^a-zA-Z0-9]|$).*",
-      ".*(^|[^a-zA-Z0-9])process(ed|ing)?([^a-zA-Z0-9]|$).*",
-      ".*(^|[^a-zA-Z0-9])order([^a-zA-Z0-9]|$).*",
-      ".*(^|[^a-zA-Z0-9])rma([^a-zA-Z0-9]|$).*",
-      ".*(^|[^a-zA-Z0-9])receive?(d|ing)?([^a-zA-Z0-9]|$).*",
-      ".*(^|[^a-zA-Z0-9])request([^a-zA-Z0-9]|$).*",
-      ".*(^|[^a-zA-Z0-9])your?([^a-zA-Z0-9]|$).*"
-    ]
+    )
   ) {
     fileinto "shopping";
     fileinto "returns";


### PR DESCRIPTION
## Paper trail: returns capture
Amazon return-dropoff confirmations (subject *"Dropoff confirmed for …"*, sender `return@amazon.com`) were never captured: the returns rule required `return`/`refund`/`rma` in the **subject**, and the returns word was only in the sender.

Restructured the rule to `anyof`:

- **A returns sender is sufficient on its own** — matches `return`/`refund` in `from` / `X-Simplelogin-Original-From`, with no subject keyword required (the subject often never mentions the return).
- **Otherwise**, the original subject logic applies — `allof(` a return word `+` a logistics/confirmation word `)` in the subject.

`rma` is intentionally **not** in the sender check (a bare `rma` token in a domain like `rma.org` is too likely an unrelated acronym); it remains in the subject limbs.

All actions unchanged.

> Note: `addflag "\\Seen"` in this rule only fires for senders already in `:addrbook:personal` (a file-wide pattern). Matched returns mail from an unknown sender goes to Paper Trail *unread*.

## Alerts: discount-code regex
Require `off` after the percentage (`NN% off` rather than bare `NN%`) so stray figures like `5%` in unrelated subjects aren't treated as discount-code alerts.

Tests: `bash tests/generate_test.sh` → 29 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)