### PR TITLE
Match plural statement(s)/disclosure(s) so statement emails reach Paper Trail

### DIFF
--- a/filters/04 - alerts.sieve
+++ b/filters/04 - alerts.sieve
@@ -98,7 +98,7 @@ if allof(
   ] ":addrbook:personal?label=Conversations",
   anyof (
     # exclude all statements, unless annual
-    not header :comparator "i;unicode-casemap" :regex "Subject" ".*(^|[^a-zA-Z0-9])statement([^a-zA-Z0-9]|$).*", 
+    not header :comparator "i;unicode-casemap" :regex "Subject" ".*(^|[^a-zA-Z0-9])statement(s)?([^a-zA-Z0-9]|$).*", 
     header :comparator "i;unicode-casemap" :regex "Subject" ".*(^|[^a-zA-Z0-9])annual([^a-zA-Z0-9]|$).*"
   ),
   anyof(
@@ -205,7 +205,7 @@ if allof(
       ".*(^|[^a-zA-Z0-9])credit(s)?([^a-zA-Z0-9]|$).*",
       ".*(^|[^a-zA-Z0-9])decision([^a-zA-Z0-9]|$).*",
       ".*(^|[^a-zA-Z0-9])did you mean([^a-zA-Z0-9]|$).*",
-      ".*(^|[^a-zA-Z0-9])disclosure([^a-zA-Z0-9]|$).*",
+      ".*(^|[^a-zA-Z0-9])disclosure(s)?([^a-zA-Z0-9]|$).*",
       ".*(^|[^a-zA-Z0-9])dispute([^a-zA-Z0-9]|$).*",
       ".*(^|[^a-zA-Z0-9-])end(s|ing)([^a-zA-Z0-9]|$).*",
       ".*(^|[^a-zA-Z0-9])expir(y|ed|es|ing|ation)([^a-zA-Z0-9]|$).*",

--- a/filters/05 - paper trail.sieve
+++ b/filters/05 - paper trail.sieve
@@ -64,7 +64,7 @@ if not anyof(
   if header :comparator "i;unicode-casemap" :regex ["Subject"] [
     ".*(^|[^a-zA-Z0-9])bill([^a-zA-Z0-9]|$).*",
     ".*(^|[^a-zA-Z0-9])report.*securities([^a-zA-Z0-9]|$).*", # Fidelity securites loan statements
-    ".*(^|[^a-zA-Z0-9])e?statement([^a-zA-Z0-9]|$).*",
+    ".*(^|[^a-zA-Z0-9])e?statement(s)?([^a-zA-Z0-9]|$).*",
     ".*(^|[^a-zA-Z0-9])your.*transaction history([^a-zA-Z0-9]|$).*"
   ] {
 


### PR DESCRIPTION
## Problem

A Fidelity email `New account statements and disclosures available` was filed into `alerts` instead of `statements` / Paper Trail.

Cause: the relevant patterns anchored on the **singular** word with a hard non-alphanumeric boundary, e.g. `statement([^a-zA-Z0-9]|$)`. For a plural subject (`statements`), the trailing `s` is alphanumeric so the boundary fails and the regex doesn't match. Two consequences:

1. The alerts statement-exclusion guard (`04 - alerts.sieve:101`) failed to exclude the email, so the `account` + `new` "requiring action" rule fired and filed it to `alerts` with `stop` — before it ever reached Paper Trail.
2. Even if it had reached Paper Trail, the statements rule (`05 - paper trail.sieve:67`, `e?statement`) wouldn't have matched the plural either.

## Fix

Add an optional trailing `s` to the affected patterns:

- `04 - alerts.sieve:101` — statement-exclusion guard → `statement(s)?`
- `05 - paper trail.sieve:67` — statements rule → `e?statement(s)?`
- `04 - alerts.sieve:208` — `disclosure(s)?` (single-words block)

The statement exception inside the **requiring action** block (`04 - alerts.sieve:307`) is left singular intentionally.

No existing rule logic or actions change beyond broadening these matches. `bash tests/generate_test.sh` passes (29/29).