### PR TITLE
Inbox clutter audit: Amazon formats, appointments, rewards offers, mailing-list label, archive order

### DIFF
--- a/filters/03 - label decoration.sieve
+++ b/filters/03 - label decoration.sieve
@@ -3,7 +3,8 @@
 # without blocking. Use for cumulative addition of context.
 #
 # Rules:
-# - Only "subject" and "from" fields are inspected here to determine labelling.
+# - Only "subject" and "from" fields are inspected here to determine labelling,
+#   plus the List-Unsubscribe header for mailing lists.
 # - ANY match in here MUST NOT call `stop`.
 #
 # Things like utilities/services (gas, cell, internet etc.)
@@ -133,6 +134,8 @@ if allof(
 
 if anyof(
   header :comparator "i;unicode-casemap" :matches "subject" [
+    "*appointment*",
+    "*booked*",
     "*booking*",
     "*reservation*"
   ],
@@ -367,6 +370,13 @@ if header :comparator "i;unicode-casemap" :regex [
       ".*vaccin.*"
     ] {
   fileinto "medical";
+}
+
+# LABEL DECORATION - mailing lists
+# Bulk senders advertise an unsubscribe header; label them so they can be
+# reviewed and unsubscribed from in one place.
+if exists "List-Unsubscribe" {
+  fileinto "mailing list";
 }
 
 # LABEL DECORATION - contact groups

--- a/filters/04 - alerts.sieve
+++ b/filters/04 - alerts.sieve
@@ -62,8 +62,10 @@ if allof(
 }
 
 # ALERTS - discount codes (long expiration)
+# Newsletters excluded so editorial subjects ("...Are for Sale") reach The Feed.
 
 if allof(
+  not header :list "from" ":addrbook:personal?label=Newsletters",
   header :comparator "i;unicode-casemap" :regex "subject" [
     ".*(^|[^a-zA-Z0-9])[0-9]{1,3}% ?off([^a-zA-Z0-9]|$).*",
     ".*(^|[^a-zA-Z0-9])coupon([^a-zA-Z0-9]|$).*",
@@ -116,6 +118,8 @@ if allof(
 
   # ALERTS - reviews, basket prompts
   # Although these are generally wanted, we surface them as alerts so we can unsubscribe and delete.
+  # Deliberately not expired (unlike cart reminders and marketing noise below):
+  # they must stay visible until the unsubscribe is actually done.
   if allof(
     not header :comparator "i;unicode-casemap" :regex "Subject" [
       ".*(^|[^a-zA-Z0-9])activity([^a-zA-Z0-9]|$).*",
@@ -264,7 +268,8 @@ if allof(
       ".*(^|[^a-zA-Z0-9])(confirm|verify) your.*(purchase|order|payment|transaction)([^a-zA-Z0-9]|$).*",
       ".*(^|[^a-zA-Z0-9])pin code([^a-zA-Z0-9]|$).*",  # 'Pin code for order status check'
       ".*(^|[^a-zA-Z0-9])your code([^a-zA-Z0-9]|$).*",  # "Here is your code" (don't add your to main limbs, too broad)
-      ".*(^|[^a-zA-Z0-9])sign in ?to([^a-zA-Z0-9]|$).*"  # email login links
+      ".*(^|[^a-zA-Z0-9])sign in ?to([^a-zA-Z0-9]|$).*",  # email login links
+      ".*(^|[^a-zA-Z0-9])(magic|secure) link([^a-zA-Z0-9]|$).*"  # "Your secure link to Claude.ai is here"
     ],
     allof(
       header :comparator "i;unicode-casemap" :regex "subject" [

--- a/filters/04 - alerts.sieve
+++ b/filters/04 - alerts.sieve
@@ -71,7 +71,10 @@ if allof(
     ".*(^|[^a-zA-Z0-9])coupon([^a-zA-Z0-9]|$).*",
     ".*(^|[^a-zA-Z0-9])discount([^a-zA-Z0-9]|$).*",
     ".*(^|[^a-zA-Z0-9])sale([^a-zA-Z0-9]|$).*",
-    ".*(^|[^a-zA-Z0-9])voucher([^a-zA-Z0-9]|$).*"
+    ".*(^|[^a-zA-Z0-9])voucher([^a-zA-Z0-9]|$).*",
+    # Capital One Shopping - "Activate Rewards on items like...", "Spend $75, get $25 in Rewards"
+    ".*(^|[^a-zA-Z0-9])(activate|earn|get).*rewards([^a-zA-Z0-9]|$).*",
+    ".*(^|[^a-zA-Z0-9])spend \\$?[0-9]+([^a-zA-Z0-9]|$).*"
   ],
   not header :comparator "i;unicode-casemap" :regex "subject" [
     ".*(^|[^a-zA-Z0-9])download([^a-zA-Z0-9]|$).*"
@@ -105,8 +108,19 @@ if allof(
   ),
   anyof(
     # exclude tips, unless flagged as important
-    not header :comparator "i;unicode-casemap" :regex "Subject" ".*(^|[^a-zA-Z0-9])tip(s)?([^a-zA-Z0-9]|$).*", 
+    not header :comparator "i;unicode-casemap" :regex "Subject" ".*(^|[^a-zA-Z0-9])tip(s)?([^a-zA-Z0-9]|$).*",
     header :comparator "i;unicode-casemap" :regex "Subject" ".*(^|[^a-zA-Z0-9])important([^a-zA-Z0-9]|$).*"
+  ),
+  anyof(
+    # exclude appointment bookings and reminders (go to Paper Trail), unless cancelled or rescheduled
+    not header :comparator "i;unicode-casemap" :regex "Subject" [
+      # <copy PAPER TRAIL - appointments>
+      ".*(^|[^a-zA-Z0-9])appointment.*(book(ed|ing)|confirm(ed|ation)|is on|today|tomorrow|upcoming)([^a-zA-Z0-9]|$).*",
+      ".*(^|[^a-zA-Z0-9])(remind(er)?|upcoming).*appointment([^a-zA-Z0-9]|$).*",
+      ".*(^|[^a-zA-Z0-9])booked:([^a-zA-Z0-9]|$).*"
+      # </copy PAPER TRAIL - appointments>
+    ],
+    header :comparator "i;unicode-casemap" :regex "Subject" ".*(^|[^a-zA-Z0-9])(cancel|reschedul).*"
   ),
   not header :comparator "i;unicode-casemap" :regex "subject" [
     ".*(^|[^a-zA-Z0-9])(associate|report).*id([^a-zA-Z0-9]|$).*", # Amazon associates reports

--- a/filters/04 - alerts.sieve
+++ b/filters/04 - alerts.sieve
@@ -62,10 +62,8 @@ if allof(
 }
 
 # ALERTS - discount codes (long expiration)
-# Newsletters excluded so editorial subjects ("...Are for Sale") reach The Feed.
 
 if allof(
-  not header :list "from" ":addrbook:personal?label=Newsletters",
   header :comparator "i;unicode-casemap" :regex "subject" [
     ".*(^|[^a-zA-Z0-9])[0-9]{1,3}% ?off([^a-zA-Z0-9]|$).*",
     ".*(^|[^a-zA-Z0-9])coupon([^a-zA-Z0-9]|$).*",
@@ -114,11 +112,7 @@ if allof(
   anyof(
     # exclude appointment bookings and reminders (go to Paper Trail), unless cancelled or rescheduled
     not header :comparator "i;unicode-casemap" :regex "Subject" [
-      # <copy PAPER TRAIL - appointments>
-      ".*(^|[^a-zA-Z0-9])appointment.*(book(ed|ing)|confirm(ed|ation)|is on|today|tomorrow|upcoming)([^a-zA-Z0-9]|$).*",
-      ".*(^|[^a-zA-Z0-9])(remind(er)?|upcoming).*appointment([^a-zA-Z0-9]|$).*",
-      ".*(^|[^a-zA-Z0-9])booked:([^a-zA-Z0-9]|$).*"
-      # </copy PAPER TRAIL - appointments>
+      {{inline filters/shared/appointments.txt}}
     ],
     header :comparator "i;unicode-casemap" :regex "Subject" ".*(^|[^a-zA-Z0-9])(cancel|reschedul).*"
   ),

--- a/filters/05 - paper trail.sieve
+++ b/filters/05 - paper trail.sieve
@@ -276,11 +276,7 @@ if not anyof(
     # PAPER TRAIL - appointments
     # Bookings and reminders only; cancellations and reschedules are caught by Alerts first.
 
-    # <PAPER TRAIL - appointments>
-    ".*(^|[^a-zA-Z0-9])appointment.*(book(ed|ing)|confirm(ed|ation)|is on|today|tomorrow|upcoming)([^a-zA-Z0-9]|$).*",
-    ".*(^|[^a-zA-Z0-9])(remind(er)?|upcoming).*appointment([^a-zA-Z0-9]|$).*",
-    ".*(^|[^a-zA-Z0-9])booked:([^a-zA-Z0-9]|$).*"
-    # </PAPER TRAIL - appointments>
+    {{inline filters/shared/appointments.txt}}
   ] {
 
     fileinto "reservations";

--- a/filters/05 - paper trail.sieve
+++ b/filters/05 - paper trail.sieve
@@ -271,6 +271,27 @@ if not anyof(
     }
     fileinto "Paper Trail";
     stop;
+  } elsif header :comparator "i;unicode-casemap" :regex "subject" [
+
+    # PAPER TRAIL - appointments
+    # Bookings and reminders only; cancellations and reschedules are caught by Alerts first.
+
+    # <PAPER TRAIL - appointments>
+    ".*(^|[^a-zA-Z0-9])appointment.*(book(ed|ing)|confirm(ed|ation)|is on|today|tomorrow|upcoming)([^a-zA-Z0-9]|$).*",
+    ".*(^|[^a-zA-Z0-9])(remind(er)?|upcoming).*appointment([^a-zA-Z0-9]|$).*",
+    ".*(^|[^a-zA-Z0-9])booked:([^a-zA-Z0-9]|$).*"
+    # </PAPER TRAIL - appointments>
+  ] {
+
+    fileinto "reservations";
+
+    expire "day" "${paper_trail_expiry_relative_days}";
+    fileinto "expiring";
+    if header :list "from" ":addrbook:personal" {
+      addflag "\\Seen";
+    }
+    fileinto "Paper Trail";
+    stop;
   } elsif anyof(
 
     # PAPER TRAIL - receipts

--- a/filters/05 - paper trail.sieve
+++ b/filters/05 - paper trail.sieve
@@ -65,7 +65,8 @@ if not anyof(
     ".*(^|[^a-zA-Z0-9])bill([^a-zA-Z0-9]|$).*",
     ".*(^|[^a-zA-Z0-9])report.*securities([^a-zA-Z0-9]|$).*", # Fidelity securites loan statements
     ".*(^|[^a-zA-Z0-9])e?statement(s)?([^a-zA-Z0-9]|$).*",
-    ".*(^|[^a-zA-Z0-9])your.*transaction history([^a-zA-Z0-9]|$).*"
+    ".*(^|[^a-zA-Z0-9])your.*transaction history([^a-zA-Z0-9]|$).*",
+    ".*(^|[^a-zA-Z0-9])activity on your.*account([^a-zA-Z0-9]|$).*" # Aetna claim summaries
   ] {
 
     fileinto "statements";
@@ -131,6 +132,8 @@ if not anyof(
       ".*(^|[^a-zA-Z0-9])dispatched:([^a-zA-Z0-9]|$).*",
       ".*(^|[^a-zA-Z0-9])pick(- )?up confirm(ed|ation)([^a-zA-Z0-9]|$).*",
       ".*(^|[^a-zA-Z0-9])shipped:([^a-zA-Z0-9]|$).*",
+      # Amazon - "Shipped 3 items: Laptop Accessories, Water Bottles"
+      ".*(^|[^a-zA-Z0-9])(arriv(ed|ing)|delivered|dispatched|shipped) [0-9]+ items?:([^a-zA-Z0-9]|$).*",
       ".*(^|[^a-zA-Z0-9])shipping.*confirm(ed|ation)([^a-zA-Z0-9]|$).*",
       ".*(^|[^a-zA-Z0-9])shipping.*accept(ed|ation)([^a-zA-Z0-9]|$).*",
       ".*(^|[^a-zA-Z0-9])shipping information([^a-zA-Z0-9]|$).*",
@@ -142,7 +145,7 @@ if not anyof(
         ".*(^|[^a-zA-Z0-9])delivery([^a-zA-Z0-9]|$).*",
         ".*(^|[^a-zA-Z0-9])driver([^a-zA-Z0-9]|$).*",
         ".*(^|[^a-zA-Z0-9])gear([^a-zA-Z0-9]|$).*",
-        ".*(^|[^a-zA-Z0-9])item([^a-zA-Z0-9]|$).*",
+        ".*(^|[^a-zA-Z0-9])items?([^a-zA-Z0-9]|$).*",
         ".*(^|[^a-zA-Z0-9])label([^a-zA-Z0-9]|$).*",
         ".*(^|[^a-zA-Z0-9])order([^a-zA-Z0-9]|$).*",
         ".*(^|[^a-zA-Z0-9])package([^a-zA-Z0-9]|$).*",
@@ -298,6 +301,8 @@ if not anyof(
       ".*invoice.*",
       ".*(^|[^a-zA-Z0-9])order #? ?[0-9]+([^a-zA-Z0-9]|$).*",
       ".*(^|[^a-zA-Z0-9])ordered:([^a-zA-Z0-9]|$).*",
+      # Amazon - "Ordered 1 item: Camera Accessories"
+      ".*(^|[^a-zA-Z0-9])ordered [0-9]+ items?:([^a-zA-Z0-9]|$).*",
       ".*receipt.*"
     ],
 
@@ -312,6 +317,7 @@ if not anyof(
         "*credit*",
         "*domain*",
         "*earnings*",
+        "*folio*", # hotel folios
         "*forwarding request*",
         "*item*",
         "*order*",

--- a/filters/07 - needs admin and archive.sieve
+++ b/filters/07 - needs admin and archive.sieve
@@ -40,28 +40,11 @@ if allof(
   stop;
 }
 
-# SCREENER - final fallthrough
-# Anything that makes it this far and has a sender not added into the address book
-# (with or without a Contact Group) will go to the Screener.
-#
-# This includes items going to Paper Trail, to make sure we're aware of new contacts.
-#
-# Even with mail that has been labelled using an aliased address,
-# an aliased address is really "me", not "from", and so should go to screener
-# if the contact using it is unexpected.
-#
-# Doesn't drag every single old item into Screener,
-# uses migration date to just get contact group representation clean from that date.
-
-if allof(
-  string :comparator "i;ascii-numeric" :value "ge" "${received_julian_day}" "${migration_julian_day}",
-not header :list "from" ":addrbook:personal") {
-  fileinto "inbox";
-  stop;
-}
-
 # ARCHIVE - for addresses we are aware of and want to hide in future (airbnb, booking.com, agoda, view through app instead)
 # and that arent't alerts, auto hide/archive these
+#
+# Must run before the screener fallthrough: booking.com/agoda relay senders are
+# unique per booking and never in the address book, so they'd otherwise hit inbox.
 
 if allof(
   anyof(
@@ -83,23 +66,22 @@ if allof(
   stop;
 }
 
+# SCREENER - final fallthrough
+# Anything that makes it this far and has a sender not added into the address book
+# (with or without a Contact Group) will go to the Screener.
+#
+# This includes items going to Paper Trail, to make sure we're aware of new contacts.
+#
+# Even with mail that has been labelled using an aliased address,
+# an aliased address is really "me", not "from", and so should go to screener
+# if the contact using it is unexpected.
+#
+# Doesn't drag every single old item into Screener,
+# uses migration date to just get contact group representation clean from that date.
+
 if allof(
-  anyof(
-    header :list [
-      "from",
-      "X-Simplelogin-Original-From"
-    ] ":addrbook:personal?label=auto-archive",
-    header :comparator "i;unicode-casemap" :matches [
-      "from",
-      "X-Simplelogin-Original-From"
-    ] [
-      "*through booking.com*",
-      "*via booking.com*"
-    ]
-  ),
-  string :comparator "i;ascii-numeric" :value "ge" "${received_julian_day}" "${migration_julian_day}"
-) {
-  addflag "\\Seen";
-  fileinto "archive";
+  string :comparator "i;ascii-numeric" :value "ge" "${received_julian_day}" "${migration_julian_day}",
+not header :list "from" ":addrbook:personal") {
+  fileinto "inbox";
   stop;
 }

--- a/filters/shared/appointments.txt
+++ b/filters/shared/appointments.txt
@@ -1,0 +1,3 @@
+".*(^|[^a-zA-Z0-9])appointment.*(book(ed|ing)|confirm(ed|ation)|is on|today|tomorrow|upcoming)([^a-zA-Z0-9]|$).*",
+".*(^|[^a-zA-Z0-9])(remind(er)?|upcoming).*appointment([^a-zA-Z0-9]|$).*",
+".*(^|[^a-zA-Z0-9])booked:([^a-zA-Z0-9]|$).*"


### PR DESCRIPTION
## Summary
Audit of inbox clutter against the existing filter flow. All changes stay within existing limbs. Rebased on main (picks up the shared-snippet mechanism and the Newsletters early-return in alerts).

**Additive pattern coverage**
- `05 paper trail` tracking: Amazon `Shipped N item(s):` (and arrived/delivered/dispatched variants, any count); tracking noun `item` now also matches `items`
- `05 paper trail` receipts: Amazon `Ordered N item(s):`; `folio` added as a receipt noun (hotel folios)
- `05 paper trail` statements: `Activity on your … account` (insurer claim summaries / EOBs)
- `05 paper trail` **new appointments limb**: `appointment` + booked/confirmed/reminder/today/tomorrow/is on/upcoming, and `Booked:` → `reservations`, seen, Paper Trail, 2-year expiry. Patterns live in `filters/shared/appointments.txt` (a build-time snippet like the existing `conversations.txt`, not a filter — `dist/` still has the same seven files in the same order) and are inlined here and in the alerts guard.
- `04 alerts` requiring-action: `magic link` / `secure link` (email login links, 7-day expiry)
- `04 alerts` discount codes: `(activate|earn|get) … rewards` and `spend $NN` (Capital One Shopping offers; main's `% off` change means `4.5% Rewards` no longer matches on the percentage alone)
- `03 label decoration` reservations: `*appointment*`, `*booked*`
- `03 label decoration` **new**: `exists "List-Unsubscribe"` → `mailing list` label (needs the label created in Proton)

**Logic fixes (confirmed with owner)**
- `04 alerts` exclusions: appointment bookings/reminders no longer alert (they were hitting `reminder`/`action` before Paper Trail could run), unless the subject also contains cancel/reschedule. Same `anyof(not X, unless Y)` shape as the statement/annual and tips/important exclusions.
- `07`: auto-archive block moved above the unknown-sender fallthrough. Booking.com/Agoda relay addresses are unique per booking and never in the address book, so the fallthrough always won and the archive rule never fired. The second archive block was a strict subset of the first's regex and is removed.
- `04 alerts` reviews: comment added documenting that the missing `expire` is intentional (must stay until unsubscribed).

**Scripts**
- `generate.sh` and `upload.sh` now `cd` to the repo root first (same as the test runner). Running `upload.sh` from `scripts/` previously wrote `proton-session.json` into an un-ignored `scripts/private/` and could not find `dist/`.
- `CHARACTER_LIMIT` is env-overridable; the test sets it directly instead of sed-patching a temp copy of the script.

## Test plan
- [x] `bash tests/generate_test.sh --fail-fast` — 29 passed
- [x] `generate.sh` run from a directory outside the repo produces the seven `dist/` files
- [x] Generated output inspected: appointments snippet expands into 04 and 05; bracket balance checked on 03/04/05/07 (no local sieve linter)
- [ ] Recreate `private/contact-groups.txt`, `private/alias-patterns.txt`, `private/address-patterns.txt` (main renamed these; see `private-examples/`)
- [ ] Create `mailing list` label in Proton
- [ ] Regenerate with `scripts/generate.sh` and upload/re-paste filters 03, 04, 05, 07
- [ ] Confirm next Amazon "Ordered N item(s):" lands in Paper Trail / receipts, "Shipped N items:" in Paper Trail / tracking
- [ ] Confirm next Rula reminder lands in Paper Trail / reservations as seen, and a cancellation still alerts
- [ ] Confirm next Booking.com relay email is archived + seen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtLietzYCcT49efot7j8cR