### PR TITLE
Scripts: run from any directory; fail fast on missing private lists

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
 # ============================================================
 # Configuration
 # ============================================================
@@ -7,7 +9,7 @@
 # Maximum characters per Proton Mail filter, as enforced by Proton.
 # Filters are packed greedily to stay within this limit.
 # To find your limit: paste a filter into Proton and note when it rejects it.
-CHARACTER_LIMIT=32000
+CHARACTER_LIMIT="${CHARACTER_LIMIT:-32000}"
 
 no_paste=false
 [[ "${1:-}" == "--no-paste" ]] && no_paste=true

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -20,6 +20,8 @@
 
 set -euo pipefail
 
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
 # ============================================================
 # Configuration
 # ============================================================
@@ -71,7 +73,7 @@ fi
 printf "Run generate.sh to refresh output files first? [y/N] "
 read -r refresh
 if [[ "$refresh" == [yY] ]]; then
-    bash "$(dirname "$0")/generate.sh" --no-paste
+    bash scripts/generate.sh --no-paste
 fi
 
 # ============================================================

--- a/tests/generate_test.sh
+++ b/tests/generate_test.sh
@@ -52,11 +52,7 @@ run_generate() {
 
 run_generate_with_limit() {
     local limit="$1"
-    local patched
-    patched=$(mktemp)
-    sed "s/^CHARACTER_LIMIT=.*/CHARACTER_LIMIT=$limit/" "$GENERATE" > "$patched"
-    printf "\n\n\n\n\n\n\n\n\n" | bash "$patched" > /dev/null 2>&1 || true
-    rm "$patched"
+    printf "\n\n\n\n\n\n\n\n\n" | CHARACTER_LIMIT="$limit" bash "$GENERATE" > /dev/null 2>&1 || true
 }
 
 # ── tests ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Follow-up to #9.

**Run from any directory**
- `generate.sh` and `upload.sh` now `cd` to the repo root first, the same way `tests/generate_test.sh` already does. Both used cwd-relative paths, so running `upload.sh` from `scripts/` could not find `dist/` and wrote `proton-session.json` into `scripts/private/` — a directory `.gitignore`'s `private/**` does not cover, leaving credentials as an untracked file.
- `upload.sh` calls `scripts/generate.sh` directly instead of `$(dirname "$0")/generate.sh`, which resolved against the original cwd.
- `CHARACTER_LIMIT` is env-overridable; the test sets it directly instead of sed-patching a temp copy of the script, which the `cd` would have broken.

**Fail fast on missing private lists**
- The missing-file check lived inside `read_list_elements`, which runs in a process substitution, so its `exit 1` only ended the subshell and the build carried on, producing seven files with empty expansions. All `list_files` are now validated before the build; each missing file is reported once and the script exits 1 without touching `dist/`.
- `private-examples/address-patterns.txt` was missing, so copying the examples never produced a working set. Added; the test fixture setup copies it rather than synthesising one.

## Test plan
- [x] `bash tests/generate_test.sh --fail-fast` — 29 passed
- [x] `generate.sh --no-paste` from a directory outside the repo produces the seven `dist/` files
- [x] `generate.sh --no-paste` with `private/*.txt` absent exits 1, lists each missing file once, generates nothing
- [ ] `bash scripts/upload.sh --dry-run` from `scripts/` finds `dist/` and reads `private/proton-session.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtLietzYCcT49efot7j8cR