### PR TITLE
upload.sh: prefer clipboard curl for credentials; add --apply for existing messages

### DIFF
--- a/docs/proton-api.md
+++ b/docs/proton-api.md
@@ -36,6 +36,10 @@ is to extract a live session from the browser and store it in `private/proton-se
    - `cookie` (the entire value) → `Cookie`
 6. Save to `private/proton-session.json` (see `private-examples/proton-session.json`).
 
+Or skip steps 5–6: right-click the request → **Copy as cURL**, then run `scripts/upload.sh`.
+A curl command on the clipboard always takes precedence over the saved session file and
+overwrites it, since Proton rotates the `AUTH-*` cookie value on each token refresh.
+
 **Required headers for all API requests:**
 
 ```

--- a/docs/proton-api.md
+++ b/docs/proton-api.md
@@ -152,6 +152,28 @@ Body:
 { "FilterIDs": ["id1", "id2", "id3"] }
 ```
 
+### Apply filters to existing messages
+
+```
+POST /mail/v4/messages/apply-filters
+```
+
+Body (either form):
+```json
+{ "FilterIDs": ["id1", "id2", "id3"] }
+```
+```json
+{ "AllFilters": 1 }
+```
+
+The request returns immediately; the server processes the mailbox in the background
+("this might take a few minutes"). There is no job ID or progress endpoint. All IDs
+in one request run as a single job that evaluates the filters in their configured
+order per message, the same way incoming mail is processed. The Proton settings UI
+only ever sends one ID per request, so applying several filters from the UI submits
+independent jobs whose relative ordering is not guaranteed. `scripts/upload.sh --apply`
+sends one request with every uploaded filter ID.
+
 ---
 
 ## Filter naming convention for this repo

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -4,9 +4,10 @@
 # REQUIREMENTS:
 #   - jq (JSON processor): brew install jq | apt install jq
 #   - Session credentials (checked in order):
-#     1. PROTON_UID + PROTON_COOKIE env vars
-#     2. private/proton-session.json
-#     3. Clipboard or paste: "Copy as cURL" from browser dev tools
+#     1. Clipboard: "Copy as cURL" from browser dev tools (always wins if present)
+#     2. PROTON_UID + PROTON_COOKIE env vars
+#     3. private/proton-session.json
+#     4. Interactive paste of a cURL command
 #
 # USAGE:
 #   bash scripts/upload.sh [--dry-run] [hey-proton-NN.sieve ...]
@@ -40,7 +41,7 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --dry-run) dry_run=true; shift ;;
         --help|-h)
-            sed -n '3,20p' "$0" | sed 's/^# \{0,1\}//'
+            sed -n '3,21p' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         dist/hey-proton-*.sieve|hey-proton-*.sieve)
@@ -77,7 +78,7 @@ if [[ "$refresh" == [yY] ]]; then
 fi
 
 # ============================================================
-# Load credentials (env vars take priority over JSON file)
+# Load credentials (clipboard curl > env vars > session file > paste)
 # ============================================================
 
 parse_curl_command() {
@@ -86,11 +87,43 @@ parse_curl_command() {
     COOKIE_VALUE=$(printf "%s" "$curl_str" | grep -oiE "cookie: [^'\"]+" | head -1 | sed -E 's/[Cc]ookie: //' || true)
 }
 
-UID_VALUE="${PROTON_UID:-}"
-COOKIE_VALUE="${PROTON_COOKIE:-}"
+read_clipboard() {
+    if command -v pbpaste &>/dev/null; then
+        pbpaste 2>/dev/null || true
+    elif command -v xclip &>/dev/null; then
+        xclip -selection clipboard -o 2>/dev/null || true
+    elif command -v xsel &>/dev/null; then
+        xsel --clipboard --output 2>/dev/null || true
+    fi
+}
 
-# 1. Try env vars (already set above)
-# 2. Try session file
+save_session() {
+    printf "Credentials extracted. Saving to %s for reuse.\n\n" "$session_file"
+    mkdir -p "$(dirname "$session_file")"
+    jq -n --arg uid "$UID_VALUE" --arg cookie "$COOKIE_VALUE" \
+        '{"UID": $uid, "Cookie": $cookie}' > "$session_file"
+}
+
+UID_VALUE=""
+COOKIE_VALUE=""
+
+# 1. A curl command on the clipboard is the freshest source, so it wins
+#    over a saved session whose AUTH cookie may have rotated since.
+clipboard=$(read_clipboard)
+if [[ "$clipboard" == curl* ]]; then
+    parse_curl_command "$clipboard"
+    if [[ -n "$UID_VALUE" && -n "$COOKIE_VALUE" ]]; then
+        save_session
+    fi
+fi
+
+# 2. Env vars
+if [[ -z "$UID_VALUE" || -z "$COOKIE_VALUE" ]]; then
+    UID_VALUE="${PROTON_UID:-}"
+    COOKIE_VALUE="${PROTON_COOKIE:-}"
+fi
+
+# 3. Session file
 if [[ -z "$UID_VALUE" || -z "$COOKIE_VALUE" ]]; then
     if [[ -f "$session_file" ]]; then
         [[ -z "$UID_VALUE" ]]    && UID_VALUE=$(jq -r '.UID // empty' "$session_file")
@@ -98,37 +131,17 @@ if [[ -z "$UID_VALUE" || -z "$COOKIE_VALUE" ]]; then
     fi
 fi
 
-# 3. Try clipboard, then interactive paste
+# 4. Interactive paste (cat handles multi-line safely)
 if [[ -z "$UID_VALUE" || -z "$COOKIE_VALUE" ]]; then
-    if command -v pbpaste &>/dev/null; then
-        clipboard=$(pbpaste 2>/dev/null || true)
-    elif command -v xclip &>/dev/null; then
-        clipboard=$(xclip -selection clipboard -o 2>/dev/null || true)
-    elif command -v xsel &>/dev/null; then
-        clipboard=$(xsel --clipboard --output 2>/dev/null || true)
-    else
-        clipboard=""
-    fi
-
-    if [[ "$clipboard" == curl* ]]; then
-        parse_curl_command "$clipboard"
-    fi
-
-    # If clipboard didn't work, read pasted input via cat (handles multi-line safely)
-    if [[ -z "$UID_VALUE" || -z "$COOKIE_VALUE" ]]; then
-        printf "No credentials found. To authenticate:\n"
-        printf "  1. Open mail.proton.me → Cmd+Opt+I → Network tab\n"
-        printf "  2. Right-click any mail.proton.me/api/ request → Copy as cURL\n\n"
-        printf "Paste the cURL command below, then press Ctrl+D:\n"
-        curl_input=$(cat)
-        parse_curl_command "$curl_input"
-    fi
+    printf "No credentials found. To authenticate:\n"
+    printf "  1. Open mail.proton.me → Cmd+Opt+I → Network tab\n"
+    printf "  2. Right-click any mail.proton.me/api/ request → Copy as cURL\n\n"
+    printf "Paste the cURL command below, then press Ctrl+D:\n"
+    curl_input=$(cat)
+    parse_curl_command "$curl_input"
 
     if [[ -n "$UID_VALUE" && -n "$COOKIE_VALUE" ]]; then
-        printf "Credentials extracted. Saving to %s for reuse.\n\n" "$session_file"
-        mkdir -p "$(dirname "$session_file")"
-        jq -n --arg uid "$UID_VALUE" --arg cookie "$COOKIE_VALUE" \
-            '{"UID": $uid, "Cookie": $cookie}' > "$session_file"
+        save_session
     else
         printf "Error: could not extract credentials.\n" >&2
         printf "Make sure you copied a cURL command for a mail.proton.me/api/ request.\n" >&2

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -10,10 +10,13 @@
 #     4. Interactive paste of a cURL command
 #
 # USAGE:
-#   bash scripts/upload.sh [--dry-run] [hey-proton-NN.sieve ...]
+#   bash scripts/upload.sh [--dry-run] [--apply] [hey-proton-NN.sieve ...]
 #
 #   With no file arguments, uploads all dist/hey-proton-*.sieve files.
 #   --dry-run   Show what would be created/updated without making API calls.
+#   --apply     After uploading, apply the uploaded filters to existing messages
+#               as a single server-side job that evaluates them in filter order.
+#               Without this flag you are prompted whether to apply.
 #
 # SECURITY: See docs/proton-api.md before using.
 # CAUTION:  This operates on your live Proton account. Back up your existing
@@ -31,6 +34,7 @@ API_BASE="https://mail.proton.me/api"
 session_file="private/proton-session.json"
 dist_dir="dist"
 dry_run=false
+apply=false
 target_files=()
 
 # ============================================================
@@ -40,8 +44,9 @@ target_files=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --dry-run) dry_run=true; shift ;;
+        --apply) apply=true; shift ;;
         --help|-h)
-            sed -n '3,21p' "$0" | sed 's/^# \{0,1\}//'
+            sed -n '3,/^$/p' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         dist/hey-proton-*.sieve|hey-proton-*.sieve)
@@ -294,6 +299,29 @@ if [[ "$dry_run" == false && ${#ordered_ids[@]} -gt 0 ]]; then
     order_response=$(api_put "mail/v4/filters/order" "$order_body")
     check_response_code "$order_response" "set filter order"
     printf "Filter order set.\n"
+fi
+
+# ============================================================
+# Apply to existing messages
+# ============================================================
+
+# One apply-filters call with every ID runs a single job that evaluates the
+# filters in order per message, matching incoming-mail behaviour. Applying
+# filters one at a time from the Proton UI submits independent jobs whose
+# relative ordering is not guaranteed.
+if [[ "$dry_run" == false && ${#ordered_ids[@]} -gt 0 ]]; then
+    if [[ "$apply" == false ]]; then
+        printf "\nApply the uploaded filters to existing messages? [y/N] "
+        read -r apply_answer
+        [[ "$apply_answer" == [yY] ]] && apply=true
+    fi
+
+    if [[ "$apply" == true ]]; then
+        apply_body=$(printf '%s\n' "${ordered_ids[@]}" | jq -R . | jq -s '{"FilterIDs": .}')
+        apply_response=$(api_post "mail/v4/messages/apply-filters" "$apply_body")
+        check_response_code "$apply_response" "apply filters to existing messages"
+        printf "Filters are being applied to existing messages. This may take a few minutes.\n"
+    fi
 fi
 
 if [[ "$dry_run" == true ]]; then


### PR DESCRIPTION
## Summary

### Clipboard curl takes precedence over the saved session
- `scripts/upload.sh` now checks for a `Copy as cURL` command on the clipboard **before** env vars and `private/proton-session.json`, and overwrites the session file with the fresh credentials.
- Previously the saved session file was loaded first, so a freshly copied curl was never read. Proton rotates the `AUTH-*` cookie value on token refresh while the UID stays the same, so the stale cookie was sent and the script failed with `Invalid access token` until the file was deleted by hand.
- New resolution order: clipboard curl → `PROTON_UID`/`PROTON_COOKIE` → session file → interactive paste.

### `--apply`: run the uploaded filters on existing messages as one ordered job
- Proton's settings UI sends one filter ID per `apply-filters` request, so applying several filters from the UI submits independent background jobs with no ordering guarantee. That matters for hey-proton, where filter 01 must drop mail before later filters label, file, or archive it.
- The endpoint accepts a list of IDs. After the order step, `upload.sh --apply` sends a single `POST mail/v4/messages/apply-filters` with every uploaded hey-proton ID, which runs one job that evaluates the filters in configured order per message.
- Without `--apply`, the script prompts `Apply the uploaded filters to existing messages? [y/N]`. Dry runs never apply.
- Help text now prints from the header comment to its first blank line so it cannot drift as the header grows. `docs/proton-api.md` documents the credential precedence and the `apply-filters` endpoint.

## Test plan

- [x] `bash -n scripts/upload.sh` and `--help` output reviewed.
- [x] Clipboard precedence: dry run with a fake `pbpaste` on `PATH` returning a curl command extracts credentials and writes the session file; a non-curl clipboard with no session file falls through to the paste prompt.
- [x] Apply flow, with a fake `curl` on `PATH` returning canned Proton responses and logging requests:
  - `--apply` sends one `apply-filters` request with the seven hey-proton IDs in filter order and no other IDs.
  - No flag + `y` at the prompt sends the same request.
  - No flag + `n` sends no `apply-filters` request.
- [x] `bash tests/generate_test.sh` — 29 passed, 0 failed (run after the first commit; the second commit does not touch `generate.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZtbRmLU2vVc4gtn3Acjsi
