### PR TITLE
upload.sh: end pasted curl on a blank line; report 409 and unrecognised apply responses

### DIFF
--- a/docs/proton-api.md
+++ b/docs/proton-api.md
@@ -169,10 +169,19 @@ Body (either form):
 The request returns immediately; the server processes the mailbox in the background
 ("this might take a few minutes"). There is no job ID or progress endpoint. All IDs
 in one request run as a single job that evaluates the filters in their configured
-order per message, the same way incoming mail is processed. The Proton settings UI
-only ever sends one ID per request, so applying several filters from the UI submits
-independent jobs whose relative ordering is not guaranteed. `scripts/upload.sh --apply`
-sends one request with every uploaded filter ID.
+order per message, the same way incoming mail is processed.
+
+Only one apply job runs per account at a time and jobs are **not queued**. While one
+is running, any further request returns HTTP 409:
+
+```json
+{ "Code": 409, "Error": "Another action is currently in progress. Try again later", "Details": {} }
+```
+
+The Proton settings UI only ever sends one ID per request, so applying several filters
+from the UI in quick succession means every click after the first is rejected until the
+running job finishes. `scripts/upload.sh --apply` sends one request with every uploaded
+filter ID, and reports the 409 case so you know to rerun later.
 
 ---
 

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -6,8 +6,8 @@
 #   - Session credentials (checked in order):
 #     1. Clipboard: "Copy as cURL" from browser dev tools (always wins if present)
 #     2. PROTON_UID + PROTON_COOKIE env vars
-#     3. private/proton-session.json
-#     4. Interactive paste of a cURL command
+#     3. private/proton-session.json (override the path with PROTON_SESSION_FILE)
+#     4. Interactive paste of a cURL command, ended by an empty line
 #
 # USAGE:
 #   bash scripts/upload.sh [--dry-run] [--apply] [hey-proton-NN.sieve ...]
@@ -31,7 +31,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 # ============================================================
 
 API_BASE="https://mail.proton.me/api"
-session_file="private/proton-session.json"
+session_file="${PROTON_SESSION_FILE:-private/proton-session.json}"
 dist_dir="dist"
 dry_run=false
 apply=false
@@ -136,13 +136,22 @@ if [[ -z "$UID_VALUE" || -z "$COOKIE_VALUE" ]]; then
     fi
 fi
 
-# 4. Interactive paste (cat handles multi-line safely)
+# 4. Interactive paste. A "Copy as cURL" command never contains a blank
+#    line, so an empty line ends the paste; EOF (Ctrl+D) is accepted too.
+read_pasted_curl() {
+    local line
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && break
+        printf "%s\n" "$line"
+    done
+}
+
 if [[ -z "$UID_VALUE" || -z "$COOKIE_VALUE" ]]; then
     printf "No credentials found. To authenticate:\n"
     printf "  1. Open mail.proton.me → Cmd+Opt+I → Network tab\n"
     printf "  2. Right-click any mail.proton.me/api/ request → Copy as cURL\n\n"
-    printf "Paste the cURL command below, then press Ctrl+D:\n"
-    curl_input=$(cat)
+    printf "Paste the cURL command below, then press Enter on an empty line:\n"
+    curl_input=$(read_pasted_curl)
     parse_curl_command "$curl_input"
 
     if [[ -n "$UID_VALUE" && -n "$COOKIE_VALUE" ]]; then
@@ -211,13 +220,19 @@ check_response_code() {
     local response="$1"
     local context="$2"
     local code
-    code=$(printf "%s" "$response" | jq -r '.Code // 0')
-    if [[ "$code" != "1000" ]]; then
-        printf "Error in %s (Code: %s): %s\n" \
-            "$context" "$code" \
-            "$(printf "%s" "$response" | jq -r '.Error // "unknown error"')" >&2
+    code=$(printf "%s" "$response" | jq -r '.Code // empty' 2>/dev/null || true)
+    if [[ "$code" == "1000" ]]; then
+        return 0
+    fi
+    if [[ -z "$code" ]]; then
+        printf "Error in %s: unrecognised response:\n%s\n" \
+            "$context" "$(printf "%s" "$response" | head -c 1000)" >&2
         return 1
     fi
+    printf "Error in %s (Code: %s): %s\n" \
+        "$context" "$code" \
+        "$(printf "%s" "$response" | jq -r '.Error // "unknown error"')" >&2
+    return 1
 }
 
 # ============================================================
@@ -319,7 +334,14 @@ if [[ "$dry_run" == false && ${#ordered_ids[@]} -gt 0 ]]; then
     if [[ "$apply" == true ]]; then
         apply_body=$(printf '%s\n' "${ordered_ids[@]}" | jq -R . | jq -s '{"FilterIDs": .}')
         apply_response=$(api_post "mail/v4/messages/apply-filters" "$apply_body")
-        check_response_code "$apply_response" "apply filters to existing messages"
+        if ! check_response_code "$apply_response" "apply filters to existing messages"; then
+            if [[ "$(printf "%s" "$apply_response" | jq -r '.Code // empty' 2>/dev/null || true)" == "409" ]]; then
+                printf "Proton only runs one apply job at a time and does not queue them.\n" >&2
+                printf "A previous job (from the Proton UI or an earlier run) is still running.\n" >&2
+                printf "The filters are uploaded; rerun with --apply once it finishes.\n" >&2
+            fi
+            exit 1
+        fi
         printf "Filters are being applied to existing messages. This may take a few minutes.\n"
     fi
 fi


### PR DESCRIPTION
## Summary

- **Paste prompt no longer appears to hang.** Ctrl+D only signals EOF at the start of an empty line, so after pasting a multi-line curl the first Ctrl+D just flushed the last line. A "Copy as cURL" command never contains a blank line, so the paste now ends on the first empty line. EOF still works. Prompt text updated to say "press Enter on an empty line".
- **Apply-filters 409 is explained.** Proton runs one apply job per account at a time and does **not** queue them. A second request while one is running returns HTTP 409 `Another action is currently in progress. Try again later`. The script now prints why and tells you the filters are uploaded and to rerun with `--apply` later.
- **Unrecognised responses show the raw body.** A response with no `Code` field used to print `Code: 0: unknown error`. It now prints the first 1000 bytes of the body so the shape is visible.
- **`PROTON_SESSION_FILE`** overrides the session file path so test runs never touch `private/proton-session.json`.
- `docs/proton-api.md` documents the one-job-at-a-time behaviour and the 409 payload. Help text updated.

## Test plan

All against a stub `curl` on `PATH` that logs requests and returns canned responses, with `PROTON_SESSION_FILE` pointed at scratch files:

- [x] `bash -n scripts/upload.sh`; `--help` output reviewed.
- [x] Paste path: piped a multi-line curl followed by a blank line, then `y`. Credentials extracted and saved, upload ran, the `y` reached the apply prompt, one `apply-filters` request sent.
- [x] `--apply` with stub returning the real 409 payload: error line plus the three-line explanation, non-zero exit.
- [x] `--apply` with stub returning `{"Foo":1}` and with `<html>…</html>`: "unrecognised response" plus the body, no jq noise.
- [x] Live: captured the actual 409 response from `POST mail/v4/messages/apply-filters` on the account while a previous job was running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZtbRmLU2vVc4gtn3Acjsi
